### PR TITLE
Remove mdx processing for md files

### DIFF
--- a/src/common/helpers/get-metadata.ts
+++ b/src/common/helpers/get-metadata.ts
@@ -2,7 +2,6 @@ import {calculateReadingTime} from 'common/helpers'
 import {PageMeta} from 'common/types'
 import dayjs from 'dayjs'
 import parse from 'node-html-parser'
-import {ReactElement} from 'react'
 import {renderToString} from 'react-dom/server'
 
 /**
@@ -11,7 +10,7 @@ import {renderToString} from 'react-dom/server'
  * @param metaTag {string} Sought-for html tag which contains metadata
  */
 
-export function getMetadata(arg: ReactElement | string, url: string, tag = 'pagemeta') {
+export function getMetadata(arg: string, url: string) {
   const meta: Partial<PageMeta> = {
     url,
   }
@@ -19,7 +18,7 @@ export function getMetadata(arg: ReactElement | string, url: string, tag = 'page
   try {
     const pageString = typeof arg === 'string' ? arg : renderToString(arg)
     const pageHtml = parse(pageString)
-    const metaElement = pageHtml.querySelector(tag)
+    const metaElement = pageHtml.querySelector('meta')
 
     if (!metaElement) {
       throw new Error('Cannot find meta element')

--- a/src/common/helpers/server/get-blog-posts.ts
+++ b/src/common/helpers/server/get-blog-posts.ts
@@ -42,7 +42,7 @@ export const getBlogPosts = async (options?: getBlogPostsOptions) => {
     await Promise.all(
       files.slice(start, start + limit).map(async (file) => {
         const fileString = (await readFile(file)).toString()
-        return getMetadata(fileString, filePathToUrl(file, {base: 'blog'}), 'meta')
+        return getMetadata(fileString, filePathToUrl(file, {base: 'blog'}))
       }),
     )
   ).filter((meta) => typeof meta.title === 'string')


### PR DESCRIPTION
Now md files not processing by mdx and supports only markdown syntax (except meta tag, its still parsing for meta purposes)